### PR TITLE
turn off soft MIDI Thru

### DIFF
--- a/Code/Traktorino/Traktorino.ino
+++ b/Code/Traktorino/Traktorino.ino
@@ -124,7 +124,9 @@ Thread threadReadButtons; // thread para controlar os botoes
 void setup() {
 
   Serial.begin(31250); // 115200 for hairless - 31250 for MOCO lufa
-
+  
+  MIDI.turnThruOff();
+  
   /////////////////////////////////////////////
   // Midi in
   MIDI.setHandleControlChange(handleControlChange);


### PR DESCRIPTION
turn off soft MIDI Thru, prevents some DJ software from creating an infinite send/receive loop